### PR TITLE
Fix jetls path in Windows

### DIFF
--- a/src-tauri/src/lsp.rs
+++ b/src-tauri/src/lsp.rs
@@ -225,7 +225,7 @@ pub async fn lsp_start(app: tauri::AppHandle, workspace_path: String) -> Result<
         let home = dirs_next::home_dir()
             .ok_or("Cannot determine home directory")?;
         let jetls_bin = if cfg!(windows) {
-            home.join(".julia").join("bin").join("jetls.exe")
+            home.join(".julia").join("bin").join("jetls.bat")
         } else {
             home.join(".julia").join("bin").join("jetls")
         };


### PR DESCRIPTION
Pkg.jl app ends with .bat extension instead of .exe in Windows. You can find relevant code in below link

https://github.com/JuliaLang/Pkg.jl/blob/4cbe4a13b38b2b767c5cabf3a029d8dd2630aa8d/src/Apps/Apps.jl#L486